### PR TITLE
Changed gRPC protocol to thrift by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .PHONY: test bins clean
 PROJECT_ROOT = github.com/uber-common/cadence-samples
 
+# change this to grpc to use gRPC transport or leave it blank to use thrift
+TAGS = ''
+
 export PATH := $(GOPATH)/bin:$(PATH)
 
 # default target
@@ -70,88 +73,88 @@ TEST_DIRS=./cmd/samples/cron \
 
 
 cancelactivity:
-	go build -i -o bin/cancelactivity cmd/samples/recipes/cancelactivity/*.go
+	go build -tags $(TAGS) -o bin/cancelactivity cmd/samples/recipes/cancelactivity/*.go
 
 helloworld:
-	go build -i -o bin/helloworld cmd/samples/recipes/helloworld/*.go
+	go build -tags $(TAGS) -o bin/helloworld cmd/samples/recipes/helloworld/*.go
 
 branch:
-	go build -i -o bin/branch cmd/samples/recipes/branch/*.go
+	go build -tags $(TAGS) -o bin/branch cmd/samples/recipes/branch/*.go
 
 childworkflow:
-	go build -i -o bin/childworkflow cmd/samples/recipes/childworkflow/*.go
+	go build -tags $(TAGS) -o bin/childworkflow cmd/samples/recipes/childworkflow/*.go
 
 choice:
-	go build -i -o bin/choice cmd/samples/recipes/choice/*.go
+	go build -tags $(TAGS) -o bin/choice cmd/samples/recipes/choice/*.go
 
 dynamic:
-	go build -i -o bin/dynamic cmd/samples/recipes/dynamic/*.go
+	go build -tags $(TAGS) -o bin/dynamic cmd/samples/recipes/dynamic/*.go
 
 greetings:
-	go build -i -o bin/greetings cmd/samples/recipes/greetings/*.go
+	go build -tags $(TAGS) -o bin/greetings cmd/samples/recipes/greetings/*.go
 
 pickfirst:
-	go build -i -o bin/pickfirst cmd/samples/recipes/pickfirst/*.go
+	go build -tags $(TAGS) -o bin/pickfirst cmd/samples/recipes/pickfirst/*.go
 
 mutex:
-	go build -i -o bin/mutex cmd/samples/recipes/mutex/*.go
+	go build -tags $(TAGS) -o bin/mutex cmd/samples/recipes/mutex/*.go
 
 retryactivity:
-	go build -i -o bin/retryactivity cmd/samples/recipes/retryactivity/*.go
+	go build -tags $(TAGS) -o bin/retryactivity cmd/samples/recipes/retryactivity/*.go
 
 splitmerge:
-	go build -i -o bin/splitmerge cmd/samples/recipes/splitmerge/*.go
+	go build -tags $(TAGS) -o bin/splitmerge cmd/samples/recipes/splitmerge/*.go
 
 searchattributes:
-	go build -i -o bin/searchattributes cmd/samples/recipes/searchattributes/*.go
+	go build -tags $(TAGS) -o bin/searchattributes cmd/samples/recipes/searchattributes/*.go
 
 timer:
-	go build -i -o bin/timer cmd/samples/recipes/timer/*.go
+	go build -tags $(TAGS) -o bin/timer cmd/samples/recipes/timer/*.go
 
 localactivity:
-	go build -i -o bin/localactivity cmd/samples/recipes/localactivity/*.go
+	go build -tags $(TAGS) -o bin/localactivity cmd/samples/recipes/localactivity/*.go
 
 query:
-	go build -i -o bin/query cmd/samples/recipes/query/*.go
+	go build -tags $(TAGS) -o bin/query cmd/samples/recipes/query/*.go
 
 consistentquery:
-	go build -i -o bin/consistentquery cmd/samples/recipes/consistentquery/*.go
+	go build -tags $(TAGS) -o bin/consistentquery cmd/samples/recipes/consistentquery/*.go
 
 ctxpropagation:
-	go build -i -o bin/ctxpropagation cmd/samples/recipes/ctxpropagation/*.go
+	go build -tags $(TAGS) -o bin/ctxpropagation cmd/samples/recipes/ctxpropagation/*.go
 
 tracing:
-	go build -i -o bin/tracing cmd/samples/recipes/tracing/*.go
+	go build -tags $(TAGS) -o bin/tracing cmd/samples/recipes/tracing/*.go
 
 cron:
-	go build -i -o bin/cron cmd/samples/cron/*.go
+	go build -tags $(TAGS) -o bin/cron cmd/samples/cron/*.go
 
 dsl:
-	go build -i -o bin/dsl cmd/samples/dsl/*.go
+	go build -tags $(TAGS) -o bin/dsl cmd/samples/dsl/*.go
 
 fileprocessing:
-	go build -i -o bin/fileprocessing cmd/samples/fileprocessing/*.go
+	go build -tags $(TAGS) -o bin/fileprocessing cmd/samples/fileprocessing/*.go
 
 expense_dummy:
-	go build -i -o bin/expense_dummy cmd/samples/expense/server/*.go
+	go build -tags $(TAGS) -o bin/expense_dummy cmd/samples/expense/server/*.go
 
 expense:
-	go build -i -o bin/expense cmd/samples/expense/*.go
+	go build -tags $(TAGS) -o bin/expense cmd/samples/expense/*.go
 
 recovery:
-	go build -i -o bin/recovery cmd/samples/recovery/*.go
+	go build -tags $(TAGS) -o bin/recovery cmd/samples/recovery/*.go
 
 pso:
-	go build -i -o bin/pso cmd/samples/pso/*.go
+	go build -tags $(TAGS) -o bin/pso cmd/samples/pso/*.go
 
 pageflow:
-	go build -i -o bin/pageflow cmd/samples/pageflow/*.go
+	go build -tags $(TAGS) -o bin/pageflow cmd/samples/pageflow/*.go
 
 signalcounter:
-	go build -i -o bin/signalcounter cmd/samples/recipes/signalcounter/*.go
+	go build -tags $(TAGS) -o bin/signalcounter cmd/samples/recipes/signalcounter/*.go
 
 crossdomain:
-	go build -o bin/crossdomain cmd/samples/recipes/crossdomain/*.go
+	go build -tags $(TAGS) -o bin/crossdomain cmd/samples/recipes/crossdomain/*.go
 
 crossdomain-setup:
 	# use the ..cadence-server --env development_xdc_cluster0 ... to set up three
@@ -165,7 +168,7 @@ crossdomain-run: crossdomain
 		split-window -v './bin/crossdomain -m "worker2"'
 
 sideeffect:
-	go build -i -o bin/sideeffect cmd/samples/recipes/sideeffect/*.go
+	go build -tags $(TAGS) -o bin/sideeffect cmd/samples/recipes/sideeffect/*.go
 
 bins: helloworld \
 	branch \

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ See instructions for running the Cadence Server: https://github.com/uber/cadence
 See instructions for using CLI to register a domain(name as "samples-domain"): https://cadenceworkflow.io/docs/cli/#quick-start
  or https://github.com/uber/cadence/blob/master/tools/cli/README.md
 
+By default cadence samples uses Thrift protocol to communicate with cadence server on port 7933. If you want to change the protocol to gRPC, add `grpc` to the [Makefile](Makefile)'s TAGS variable, and do not forget to modify the [config/development.yaml](config/development.yaml) host configuration to port `7833` then add this port to your docker-compose file. ⚠️ This port is not exposed by the default!
 
 ## Steps to run samples
 ### Build Samples

--- a/cmd/samples/common/factory.go
+++ b/cmd/samples/common/factory.go
@@ -1,18 +1,12 @@
 package common
 
 import (
-	"errors"
-
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber-go/tally"
-	apiv1 "github.com/uber/cadence-idl/go/proto/api/v1"
-	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	"go.uber.org/cadence/client"
-	"go.uber.org/cadence/compatibility"
 	"go.uber.org/cadence/encoded"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/yarpc"
-	"go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/zap"
 )
 
@@ -129,52 +123,4 @@ func (b *WorkflowClientBuilder) BuildCadenceDomainClient() (client.DomainClient,
 			},
 		},
 	), nil
-}
-
-// BuildServiceClient builds a rpc service client to cadence service
-func (b *WorkflowClientBuilder) BuildServiceClient() (workflowserviceclient.Interface, error) {
-	if err := b.build(); err != nil {
-		return nil, err
-	}
-
-	if b.dispatcher == nil {
-		b.Logger.Fatal("No RPC dispatcher provided to create a connection to Cadence Service")
-	}
-
-	clientConfig := b.dispatcher.ClientConfig(_cadenceFrontendService)
-	return compatibility.NewThrift2ProtoAdapter(
-		apiv1.NewDomainAPIYARPCClient(clientConfig),
-		apiv1.NewWorkflowAPIYARPCClient(clientConfig),
-		apiv1.NewWorkerAPIYARPCClient(clientConfig),
-		apiv1.NewVisibilityAPIYARPCClient(clientConfig),
-	), nil
-}
-
-func (b *WorkflowClientBuilder) build() error {
-	if b.dispatcher != nil {
-		return nil
-	}
-
-	if len(b.hostPort) == 0 {
-		return errors.New("HostPort is empty")
-	}
-
-	b.Logger.Debug("Creating RPC dispatcher outbound",
-		zap.String("ServiceName", _cadenceFrontendService),
-		zap.String("HostPort", b.hostPort))
-
-	b.dispatcher = yarpc.NewDispatcher(yarpc.Config{
-		Name: _cadenceClientName,
-		Outbounds: yarpc.Outbounds{
-			_cadenceFrontendService: {Unary: grpc.NewTransport().NewSingleOutbound(b.hostPort)},
-		},
-	})
-
-	if b.dispatcher != nil {
-		if err := b.dispatcher.Start(); err != nil {
-			b.Logger.Fatal("Failed to create outbound transport channel: %v", zap.Error(err))
-		}
-	}
-
-	return nil
 }

--- a/cmd/samples/common/factory_grpc.go
+++ b/cmd/samples/common/factory_grpc.go
@@ -1,0 +1,62 @@
+//go:build grpc
+
+package common
+
+import (
+	"errors"
+
+	apiv1 "github.com/uber/cadence-idl/go/proto/api/v1"
+	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
+	"go.uber.org/cadence/compatibility"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/transport/grpc"
+	"go.uber.org/zap"
+)
+
+// BuildServiceClient builds a rpc service client to cadence service
+func (b *WorkflowClientBuilder) BuildServiceClient() (workflowserviceclient.Interface, error) {
+	if err := b.build(); err != nil {
+		return nil, err
+	}
+
+	if b.dispatcher == nil {
+		b.Logger.Fatal("No RPC dispatcher provided to create a connection to Cadence Service")
+	}
+
+	clientConfig := b.dispatcher.ClientConfig(_cadenceFrontendService)
+	return compatibility.NewThrift2ProtoAdapter(
+		apiv1.NewDomainAPIYARPCClient(clientConfig),
+		apiv1.NewWorkflowAPIYARPCClient(clientConfig),
+		apiv1.NewWorkerAPIYARPCClient(clientConfig),
+		apiv1.NewVisibilityAPIYARPCClient(clientConfig),
+	), nil
+}
+
+func (b *WorkflowClientBuilder) build() error {
+	if b.dispatcher != nil {
+		return nil
+	}
+
+	if len(b.hostPort) == 0 {
+		return errors.New("HostPort is empty")
+	}
+
+	b.Logger.Debug("Creating RPC dispatcher outbound",
+		zap.String("ServiceName", _cadenceFrontendService),
+		zap.String("HostPort", b.hostPort))
+
+	b.dispatcher = yarpc.NewDispatcher(yarpc.Config{
+		Name: _cadenceClientName,
+		Outbounds: yarpc.Outbounds{
+			_cadenceFrontendService: {Unary: grpc.NewTransport().NewSingleOutbound(b.hostPort)},
+		},
+	})
+
+	if b.dispatcher != nil {
+		if err := b.dispatcher.Start(); err != nil {
+			b.Logger.Fatal("Failed to create outbound transport channel: %v", zap.Error(err))
+		}
+	}
+
+	return nil
+}

--- a/cmd/samples/common/factory_thrift.go
+++ b/cmd/samples/common/factory_thrift.go
@@ -1,0 +1,62 @@
+//go:build !grpc
+
+package common
+
+import (
+	"errors"
+
+	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/transport/tchannel"
+	"go.uber.org/zap"
+)
+
+// BuildServiceClient builds a rpc service client to cadence service
+func (b *WorkflowClientBuilder) BuildServiceClient() (workflowserviceclient.Interface, error) {
+	if err := b.build(); err != nil {
+		return nil, err
+	}
+
+	if b.dispatcher == nil {
+		b.Logger.Fatal("No RPC dispatcher provided to create a connection to Cadence Service")
+	}
+
+	clientConfig := b.dispatcher.ClientConfig(_cadenceFrontendService)
+	return workflowserviceclient.New(clientConfig), nil
+}
+
+func (b *WorkflowClientBuilder) build() error {
+	if b.dispatcher != nil {
+		return nil
+	}
+
+	if len(b.hostPort) == 0 {
+		return errors.New("HostPort is empty")
+	}
+
+	b.Logger.Debug("Creating RPC dispatcher outbound",
+		zap.String("ServiceName", _cadenceFrontendService),
+		zap.String("HostPort", b.hostPort))
+
+	ch, err := tchannel.NewChannelTransport(tchannel.ServiceName(_cadenceFrontendService))
+	if err != nil {
+		panic("Failed to setup tchannel")
+	}
+
+	b.dispatcher = yarpc.NewDispatcher(yarpc.Config{
+		Name: _cadenceClientName,
+		Outbounds: yarpc.Outbounds{
+			_cadenceFrontendService: {
+				Unary: ch.NewSingleOutbound(b.hostPort),
+			},
+		},
+	})
+
+	if b.dispatcher != nil {
+		if err := b.dispatcher.Start(); err != nil {
+			b.Logger.Fatal("Failed to create outbound transport channel: %v", zap.Error(err))
+		}
+	}
+
+	return nil
+}

--- a/cmd/samples/common/sample_helper.go
+++ b/cmd/samples/common/sample_helper.go
@@ -3,7 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -93,7 +93,7 @@ func (h *SampleHelper) SetupServiceConfig() {
 		h.configFile = defaultConfigFile
 	}
 	// Initialize developer config for running samples
-	configData, err := ioutil.ReadFile(h.configFile)
+	configData, err := os.ReadFile(h.configFile)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to log config file: %v, Error: %v", defaultConfigFile, err))
 	}

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,7 +1,9 @@
 # config for sample
 domain: "samples-domain"
 service: "cadence-frontend"
-host: "127.0.0.1:7833"
+# If you want to use gRPC protocol instead of Thrift protocol use 7833 port but
+# do not forget to expose this port on your docker-compose configuration too.
+host: "127.0.0.1:7933"
 # config for emitting metrics
 #prometheus:
 #  listenAddress: "127.0.0.1:9098"


### PR DESCRIPTION
By default these samples uses gRPC protocol which is not exposed by the default cadence-server's docker configuration.
I've written some code to provide thrift/gRPC examples with build tags and set thrift as the default protocol/port.

The reason of this pull request is to provide an easy way to try cadence, because right now the samples wont run with the provided deafult config.