### PR TITLE
Updated expense workflow timeout to 12 mins

### DIFF
--- a/cmd/samples/expense/main.go
+++ b/cmd/samples/expense/main.go
@@ -26,8 +26,8 @@ func startWorkflow(h *common.SampleHelper, expenseID string) {
 	workflowOptions := client.StartWorkflowOptions{
 		ID:                              "expense_" + uuid.New(),
 		TaskList:                        ApplicationName,
-		ExecutionStartToCloseTimeout:    time.Minute,
-		DecisionTaskStartToCloseTimeout: time.Minute,
+		ExecutionStartToCloseTimeout:    time.Minute * 12,
+		DecisionTaskStartToCloseTimeout: time.Minute * 12,
 	}
 	h.StartWorkflow(workflowOptions, sampleExpenseWorkflow, expenseID)
 }

--- a/cmd/samples/expense/workflow.go
+++ b/cmd/samples/expense/workflow.go
@@ -33,11 +33,11 @@ func sampleExpenseWorkflow(ctx workflow.Context, expenseID string) (result strin
 
 	// step 2, wait for the expense report to be approved (or rejected)
 	ao = workflow.ActivityOptions{
-		ScheduleToStartTimeout: 10 * time.Minute,
-		StartToCloseTimeout:    10 * time.Minute,
+		ScheduleToStartTimeout: time.Minute,
+		StartToCloseTimeout:    4 * time.Minute,
 	}
 	ctx2 := workflow.WithActivityOptions(ctx, ao)
-	// Notice that we set the timeout to be 10 minutes for this sample demo. If the expected time for the activity to
+	// Notice that we set the timeout to be 4 minutes for this sample demo. If the expected time for the activity to
 	// complete (waiting for human to approve the request) is longer, you should set the timeout accordingly so the
 	// cadence system will wait accordingly. Otherwise, cadence system could mark the activity as failure by timeout.
 	var status string

--- a/cmd/samples/expense/workflow_test.go
+++ b/cmd/samples/expense/workflow_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -48,6 +49,110 @@ func (s *UnitTestSuite) Test_WorkflowWithMockActivities() {
 	err := s.env.GetWorkflowResult(&workflowResult)
 	s.NoError(err)
 	s.Equal("COMPLETED", workflowResult)
+}
+
+func (s *UnitTestSuite) Test_TimeoutWithMockActivities() {
+	s.env.OnActivity(createExpenseActivity, mock.Anything, mock.Anything).Return(nil).Once()
+	// s.env.OnActivity(waitForDecisionActivity, mock.Anything, mock.Anything).Return("APPROVED", nil).Once()
+	// s.env.OnActivity(paymentActivity, mock.Anything, mock.Anything).Return(nil).Once()
+	s.env.SetWorkflowTimeout(time.Microsecond * 500)
+	s.env.SetTestTimeout(time.Minute * 10)
+
+	s.env.ExecuteWorkflow(sampleExpenseWorkflow, "test-expense-id")
+
+	var workflowResult string
+	err := s.env.GetWorkflowResult(&workflowResult)
+	s.Equal("TimeoutType: SCHEDULE_TO_CLOSE", err.Error())
+	s.Empty(workflowResult)
+}
+
+func (s *UnitTestSuite) Test_WorkflowStatusRejected() {
+	s.env.OnActivity(createExpenseActivity, mock.Anything, mock.Anything).Return(nil).Once()
+	s.env.OnActivity(waitForDecisionActivity, mock.Anything, mock.Anything).Return("REJECTED", nil).Once()
+	// s.env.OnActivity(paymentActivity, mock.Anything, mock.Anything).Return(nil).Once()
+
+	s.env.ExecuteWorkflow(sampleExpenseWorkflow, "test-expense-id")
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+	var workflowResult string
+	err := s.env.GetWorkflowResult(&workflowResult)
+	s.NoError(err)
+	s.Empty(workflowResult)
+}
+
+func (s *UnitTestSuite) Test_WorkflowStatusCancelled() {
+	s.env.OnActivity(createExpenseActivity, mock.Anything, mock.Anything).Return(nil).Once()
+	s.env.OnActivity(waitForDecisionActivity, mock.Anything, mock.Anything).Return("CANCELLED", nil).Once()
+
+	s.env.ExecuteWorkflow(sampleExpenseWorkflow, "test-expense-id")
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.NoError(s.env.GetWorkflowError())
+	var workflowResult string
+	err := s.env.GetWorkflowResult(&workflowResult)
+	s.NoError(err)
+	s.Empty(workflowResult)
+}
+
+func (s *UnitTestSuite) Test_WorkflowStatusApprovedWithPaymentError() {
+	s.env.OnActivity(createExpenseActivity, mock.Anything, mock.Anything).Return(nil).Once()
+	s.env.OnActivity(waitForDecisionActivity, mock.Anything, mock.Anything).Return("APPROVED", nil).Once()
+	s.env.OnActivity(paymentActivity, mock.Anything, mock.Anything).Return(errors.New("payment error")).Once()
+
+	s.env.ExecuteWorkflow(sampleExpenseWorkflow, "test-expense-id")
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.Error(s.env.GetWorkflowError())
+	var workflowResult string
+	err := s.env.GetWorkflowResult(&workflowResult)
+	s.Equal("payment error", err.Error())
+	s.Empty(workflowResult)
+}
+
+func (s *UnitTestSuite) Test_CreateActivityFailed() {
+	s.env.OnActivity(createExpenseActivity, mock.Anything, mock.Anything).Return(errors.New("expense id is empty")).Once()
+
+	s.env.ExecuteWorkflow(sampleExpenseWorkflow, "")
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.Error(s.env.GetWorkflowError())
+	var workflowResult string
+
+	err := s.env.GetWorkflowResult(&workflowResult)
+	s.Equal("expense id is empty", err.Error())
+	s.Empty(workflowResult)
+}
+
+func (s *UnitTestSuite) Test_WaitForDecisionActivityFailed() {
+	s.env.OnActivity(createExpenseActivity, mock.Anything, mock.Anything).Return(nil).Once()
+	s.env.OnActivity(waitForDecisionActivity, mock.Anything, mock.Anything).Return("", errors.New("failed to get decision")).Once()
+
+	s.env.ExecuteWorkflow(sampleExpenseWorkflow, "test-expense-id")
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.Error(s.env.GetWorkflowError())
+	var workflowResult string
+
+	err := s.env.GetWorkflowResult(&workflowResult)
+	s.Equal("failed to get decision", err.Error())
+	s.Empty(workflowResult)
+}
+
+func (s *UnitTestSuite) Test_PaymentActivityFailed() {
+	s.env.OnActivity(createExpenseActivity, mock.Anything, mock.Anything).Return(nil).Once()
+	s.env.OnActivity(waitForDecisionActivity, mock.Anything, mock.Anything).Return("APPROVED", nil).Once()
+	s.env.OnActivity(paymentActivity, mock.Anything, mock.Anything).Return(errors.New("payment failed")).Once()
+
+	s.env.ExecuteWorkflow(sampleExpenseWorkflow, "test-expense-id")
+
+	s.True(s.env.IsWorkflowCompleted())
+	s.Error(s.env.GetWorkflowError())
+	var workflowResult string
+
+	err := s.env.GetWorkflowResult(&workflowResult)
+	s.Equal("payment failed", err.Error())
+	s.Empty(workflowResult)
 }
 
 func (s *UnitTestSuite) Test_WorkflowWithMockServer() {

--- a/cmd/samples/expense/workflow_test.go
+++ b/cmd/samples/expense/workflow_test.go
@@ -53,8 +53,6 @@ func (s *UnitTestSuite) Test_WorkflowWithMockActivities() {
 
 func (s *UnitTestSuite) Test_TimeoutWithMockActivities() {
 	s.env.OnActivity(createExpenseActivity, mock.Anything, mock.Anything).Return(nil).Once()
-	// s.env.OnActivity(waitForDecisionActivity, mock.Anything, mock.Anything).Return("APPROVED", nil).Once()
-	// s.env.OnActivity(paymentActivity, mock.Anything, mock.Anything).Return(nil).Once()
 	s.env.SetWorkflowTimeout(time.Microsecond * 500)
 	s.env.SetTestTimeout(time.Minute * 10)
 
@@ -69,7 +67,6 @@ func (s *UnitTestSuite) Test_TimeoutWithMockActivities() {
 func (s *UnitTestSuite) Test_WorkflowStatusRejected() {
 	s.env.OnActivity(createExpenseActivity, mock.Anything, mock.Anything).Return(nil).Once()
 	s.env.OnActivity(waitForDecisionActivity, mock.Anything, mock.Anything).Return("REJECTED", nil).Once()
-	// s.env.OnActivity(paymentActivity, mock.Anything, mock.Anything).Return(nil).Once()
 
 	s.env.ExecuteWorkflow(sampleExpenseWorkflow, "test-expense-id")
 


### PR DESCRIPTION
**What changed?**

> Updated StartToCloseTimeouts for the workflow to 12 mins

**Why the change?**

> Workflow was timing out even before I approve or reject the expense report as the ExecutionStartToCloseTimeout was set to 1 min. There are three activities that have a cumulative scheduleToCloseTimeout of 12 mins but we were setting ExecutionStartToCloseTimeout for the whole workflow to just 1 min. 

<img width="1468" alt="Screenshot 2025-02-05 at 5 56 14 PM" src="https://github.com/user-attachments/assets/e7aa6675-0a1e-4bff-acb8-48d764f8f59d" />



**How did you test it?**

> Unit tested the timeout error

**Potential risks**

> No risks 


